### PR TITLE
Subtle mistake in my openat(2) code

### DIFF
--- a/src/io_uring_stubs.c
+++ b/src/io_uring_stubs.c
@@ -78,7 +78,9 @@ CAMLprim value io_uring_prep_open_stub(value v_io_uring, value v_sqe_flags, valu
     return Val_bool(true);
   }
 
-  assert(v_bstr_len >= sizeof(struct open_how));
+  if (v_bstr_len < sizeof(struct open_how)) {
+    uerror("bstr memory", Nothing);
+  }
 
   struct open_how* flags = (struct open_how*) get_bstr(v_bstr, v_bstr_pos);
 

--- a/src/io_uring_stubs.c
+++ b/src/io_uring_stubs.c
@@ -78,7 +78,7 @@ CAMLprim value io_uring_prep_open_stub(value v_io_uring, value v_sqe_flags, valu
     return Val_bool(true);
   }
 
-  if (v_bstr_len < sizeof(struct open_how)) {
+  if (Long_val(v_bstr_len) < sizeof(struct open_how)) {
     uerror("bstr memory", Nothing);
   }
 


### PR DESCRIPTION
I forgot we can just raise rather than core dumping, adjusted.